### PR TITLE
Improve sync playback with dynamic timestretch

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -41,9 +41,11 @@ def generate_fingerprint_database():
         match = pattern.match(base)
         if not match:
             print(f"[WARN] Formato de nome inesperado: {base}")
-            continue
-        track_name = match.group("track")
-        variation = match.group("variation")
+            track_name = base
+            variation = "default"
+        else:
+            track_name = match.group("track")
+            variation = match.group("variation")
 
         if track_name not in db:
             db[track_name] = {}


### PR DESCRIPTION
## Summary
- support simple filenames in `generate_fingerprint_database`
- add dynamic buffer and timestretch to handle pitch/reverse in `sync_playback.py`

## Testing
- `pip install numpy soundfile sounddevice librosa scipy tqdm --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b50151f7c83278374ab9564041da5